### PR TITLE
Re-add pattern of casting Astro.props to Props type

### DIFF
--- a/src/pages/en/core-concepts/astro-components.md
+++ b/src/pages/en/core-concepts/astro-components.md
@@ -193,7 +193,7 @@ export interface Props {
   greeting?: string;
 }
 
-const { greeting = "Hello", name } = Astro.props
+const { greeting = "Hello", name } = Astro.props as Props
 ---
 <h2>{greeting}, {name}!</h2>
 ```


### PR DESCRIPTION
this was originally added in https://github.com/withastro/docs/pull/287

It was later removed during a larger reorg:
https://github.com/withastro/docs/commit/03738d61e8fb31e7300b83b6b040f4c635bc1c8c#diff-2cea51d918d3ae4fedfce864624f37591ca58c59140f2f60c55e53641e91a661R196

but AFAICT it is, in fact, still needed to get proper type checking and autocompletion of props within the component file